### PR TITLE
fix: render zero and negative values correctly in grouped bar charts

### DIFF
--- a/ccf-common/scripts/check_v04.py
+++ b/ccf-common/scripts/check_v04.py
@@ -8,12 +8,14 @@ import contextlib
 import copy
 import io
 import json
+import math
 import re
 import runpy
 import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
+from xml.etree import ElementTree
 
 import yaml
 
@@ -392,6 +394,47 @@ def check_review_regressions(errors: list[str]) -> None:
         fail(errors, f"review validator could not run regression cases: {type(exc).__name__}: {exc}")
 
 
+def check_plot_regressions(errors: list[str]) -> None:
+    """Check grouped bars against zero, signed values, and plot bounds."""
+    try:
+        plots = runpy.run_path(str(ROOT / "ccf-visual-composer/resources/python/ccfa_plot_recipes.py"), run_name="ccfa_plot_check")
+        cases = (
+            ("all zero", [0, 0], 468.0),
+            ("positive", [1, 2], 468.0),
+            ("positive and zero", [0, 2], 468.0),
+            ("mixed signs", [-1, 0, 1], 300.0),
+            ("asymmetric signs", [-1, 0, 2], 356.0),
+            ("negative", [-2, -1], 132.0),
+            ("negative and zero", [-2, 0], 132.0),
+            ("empty", [], 468.0),
+        )
+        for name, values, baseline in cases:
+            rows = [{"group": str(index), "value": value} for index, value in enumerate(values)]
+            svg = plots["grouped_bar_chart"](rows, "group", ["value"], "Regression fixture")
+            root = ElementTree.fromstring(svg)
+            bars = [node for node in root.findall("{http://www.w3.org/2000/svg}rect") if node.get("opacity") == "0.920"]
+            if len(bars) != len(values):
+                fail(errors, f"grouped bars ({name}): incorrect bar count")
+                continue
+            heights_per_unit = []
+            for value, bar in zip(values, bars):
+                y, height = float(bar.attrib["y"]), float(bar.attrib["height"])
+                if not all(math.isfinite(number) for number in (y, height)) or height < 0 or y < 131.99 or y + height > 468.01:
+                    fail(errors, f"grouped bars ({name}): invalid geometry or bar outside plot bounds")
+                if value == 0:
+                    if height != 0 or not math.isclose(y, baseline, abs_tol=0.01):
+                        fail(errors, f"grouped bars ({name}): zero must have no height at the baseline")
+                else:
+                    anchor = y + height if value > 0 else y
+                    if height <= 0 or not math.isclose(anchor, baseline, abs_tol=0.01):
+                        fail(errors, f"grouped bars ({name}): bar must extend from zero in the value's direction")
+                    heights_per_unit.append(height / abs(value))
+            if heights_per_unit and max(heights_per_unit) - min(heights_per_unit) > 0.01:
+                fail(errors, f"grouped bars ({name}): bar heights must be proportional to magnitude")
+    except Exception as exc:
+        fail(errors, f"plot regression failed: {type(exc).__name__}: {exc}")
+
+
 def check_artifact_regressions(errors: list[str]) -> None:
     """Exercise current-file updates in one managed temporary directory."""
     try:
@@ -472,6 +515,7 @@ def main() -> int:
     check_project_and_plugins(errors)
     check_prose_regressions(errors)
     check_review_regressions(errors)
+    check_plot_regressions(errors)
     check_artifact_regressions(errors)
     if errors:
         print("CCFA validation failed:")

--- a/ccf-visual-composer/resources/python/ccfa_plot_recipes.py
+++ b/ccf-visual-composer/resources/python/ccfa_plot_recipes.py
@@ -338,14 +338,20 @@ def grouped_bar_chart(
     theme = theme or Theme(width=940, height=560)
     palette = list(palette or PALETTES["ccfa"])
     values = [float(row[key]) for row in rows for key in series_keys]
-    lo, hi = 0.0, max(values) * 1.16 if values else 1.0
+    lo = min(0.0, min(values, default=0.0)) * 1.16
+    hi = max(0.0, max(values, default=0.0)) * 1.16
+    if lo == hi:
+        hi = 1.0
     c = Canvas(theme.width, theme.height, theme)
     c.label_block(title, subtitle, note)
     left, right, top, bottom = 82, theme.width - 42, 132, theme.height - 92
+    zero_y = _scale(0.0, lo, hi, bottom, top)
     for frac in (0, 0.25, 0.5, 0.75, 1.0):
         y = _scale(lo + (hi - lo) * frac, lo, hi, bottom, top)
         c.line(left, y, right, y, theme.grid, 0.9, 0.82)
         c.text(left - 12, y + 4, _pretty(lo + (hi - lo) * frac), 11, 500, theme.muted, "end")
+    if lo < 0 < hi:
+        c.line(left, zero_y, right, zero_y, theme.muted, 1.2)
     group_w = (right - left) / max(1, len(rows))
     bar_w = min(26, group_w * 0.68 / max(1, len(series_keys)))
     for i, row in enumerate(rows):
@@ -353,12 +359,14 @@ def grouped_bar_chart(
         c.text(gx, bottom + 28, str(row[group_key]), 12, 720, theme.ink, "middle")
         for j, key in enumerate(series_keys):
             value = float(row[key])
-            h = bottom - _scale(value, lo, hi, bottom, top)
+            value_y = _scale(value, lo, hi, bottom, top)
+            h = abs(value_y - zero_y)
             x = gx - bar_w * len(series_keys) / 2 + j * bar_w
             color = palette[j % len(palette)]
-            c.rect(x + 2, bottom - h, bar_w - 4, h, color, "none", 6, 0.92)
-            if value > hi * 0.72:
-                c.text(x + bar_w / 2, bottom - h - 8, f"{_pretty(value)}{unit}", 10, 720, theme.ink, "middle")
+            c.rect(x + 2, min(value_y, zero_y), bar_w - 4, h, color, "none", 6, 0.92)
+            if abs(value) > max(abs(lo), hi) * 0.72:
+                label_y = value_y - 8 if value > 0 else value_y + 18
+                c.text(x + bar_w / 2, label_y, f"{_pretty(value)}{unit}", 10, 720, theme.ink, "middle")
     legend_x = left
     legend_y = top - 34
     for j, key in enumerate(series_keys):


### PR DESCRIPTION
Grouped bar charts currently render all-zero input as 168 px bars. Mixed positive and negative values produce negative SVG rectangle heights, while entirely negative data can point upward or extend outside the plot.

This change includes zero and both data extremes in the axis range, with a nonzero fallback for empty or all-zero input. Each bar extends from the zero baseline toward its value, using a nonnegative height. Mixed-sign charts show that baseline explicitly, and negative value labels appear below their endpoints.

The existing CI validation now checks eight cases: all-zero, positive, positive with zero, symmetric and asymmetric mixed signs, negative, negative with zero, and empty input. It verifies bar count, finite coordinates, plot bounds, direction, zero height, and proportional magnitudes.

Validation:

- Confirmed the new regression checks fail against the original implementation and pass after the fix.
- Passed all four existing repository checks:

```text
python ccf-common/scripts/check_path_privacy.py .
python ccf-common/scripts/check_sources.py
python ccf-common/scripts/check_markdown_links.py
python ccf-common/scripts/check_v04.py
```

The source registry check still reports its existing unverified-source warnings.
